### PR TITLE
Refactor Pickup Size Check Calculation

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1565,7 +1565,7 @@ Transform:
   m_GameObject: {fileID: 892591013}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8, y: -7.745, z: 10.293}
+  m_LocalPosition: {x: -8, y: -7.745, z: 9.723}
   m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3433,8 +3433,8 @@ Transform:
   m_GameObject: {fileID: 1830293212}
   serializedVersion: 2
   m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
-  m_LocalPosition: {x: -8, y: -8.306238, z: 9.444}
-  m_LocalScale: {x: 0.4, y: 0.65, z: 0.65}
+  m_LocalPosition: {x: -8, y: -8.306238, z: 7.81}
+  m_LocalScale: {x: 1, y: 0.65, z: 0.65}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 138735956}
@@ -3603,7 +3603,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899413506}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &1899413508
 Camera:
   m_ObjectHideFlags: 0
@@ -3682,6 +3682,7 @@ GameObject:
   - component: {fileID: 1945735482}
   - component: {fileID: 1945735481}
   - component: {fileID: 1945735480}
+  - component: {fileID: 1945735483}
   m_Layer: 0
   m_Name: Pickup (Platform)
   m_TagString: Pickup
@@ -3698,8 +3699,8 @@ Transform:
   m_GameObject: {fileID: 1945735478}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8, y: -7.8582387, z: 9.99}
-  m_LocalScale: {x: 0.4, y: 0.009018277, z: 1.0975285}
+  m_LocalPosition: {x: -8, y: -7.8582387, z: 9.17}
+  m_LocalScale: {x: 1, y: 0.009018277, z: 2.71495}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 138735956}
@@ -3775,6 +3776,33 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1945735478}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &1945735483
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945735478}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1954757766
 GameObject:
   m_ObjectHideFlags: 0
@@ -4291,7 +4319,7 @@ Transform:
   m_GameObject: {fileID: 2070158782}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8, y: -7.745, z: 9.704}
+  m_LocalPosition: {x: -8, y: -7.745, z: 8.698}
   m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4431,7 +4459,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
   m_LocalPosition: {x: -8, y: -8.306238, z: 10.535}
-  m_LocalScale: {x: 0.4, y: 0.65, z: 0.65}
+  m_LocalScale: {x: 1, y: 0.65, z: 0.65}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 138735956}

--- a/Assets/Scripts/AbsorbPickup.cs
+++ b/Assets/Scripts/AbsorbPickup.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using System;
 
 public class AbsorbPickup : MonoBehaviour
 {
@@ -24,9 +25,6 @@ public class AbsorbPickup : MonoBehaviour
         if ("Pickup" == collision.gameObject.tag) {
             if (isSmallEnoughToGrab(collision)) {
                 Destroy(collision.gameObject);
-                // TODO: Add the average dimensional size to the main object.
-                //     (x + y + z) / 3
-                // UnityEngine.Vector3 addedSize = new Vector3(1.0f, 1.0f, 1.0f);
                 UnityEngine.Vector3 incrementingSize = calcIncrementingSize(collision);
                 gameObject.transform.localScale += incrementingSize;
                 size += incrementingSize;
@@ -38,11 +36,11 @@ public class AbsorbPickup : MonoBehaviour
     {
         UnityEngine.Vector3 pickupSize = pickup.collider.bounds.size;
 
-        return (
-            isSmallEnoughRatio(pickupSize.x, size.x)
-            && isSmallEnoughRatio(pickupSize.y, size.y)
-            && isSmallEnoughRatio(pickupSize.z, size.z)
-        );
+        float pickupVolume = pickupSize.x * pickupSize.y * pickupSize.z;
+        float cubicRootOfPickupVol = cubicRoot(pickupSize);
+        float pickupSizeRatio = cubicRootOfPickupVol / size.x;
+
+        return (pickupSizeRatio < 0.25f);
     }
 
     static bool isSmallEnoughRatio(float pickupAxisSize, float objectAxisSize)
@@ -51,8 +49,13 @@ public class AbsorbPickup : MonoBehaviour
     }
 
     static UnityEngine.Vector3 calcIncrementingSize(Collision pickup) {
-        UnityEngine.Vector3 pickupSize = pickup.collider.bounds.size;
-        float avgSize2 = Queryable.Average((new List<float> { pickupSize.x, pickupSize.y, pickupSize.z }).AsQueryable()) / 3.14f;
-        return new UnityEngine.Vector3(avgSize2, avgSize2, avgSize2);
+        float addedSize = cubicRoot(pickup.collider.bounds.size) / 3.14f;
+        return new UnityEngine.Vector3(addedSize, addedSize, addedSize);
+    }
+
+    static float cubicRoot(UnityEngine.Vector3 size) {
+        // TODO: This needs to be fixed; I think this is using the "global" volume of the object because the object's orientation is effecting its volume calculation.
+        float volume = size.x * size.y * size.z;
+        return (float) Math.Pow(volume, (1.0f/3.0f));
     }
 }


### PR DESCRIPTION
This commit refactors the math that is used to check whether or not an object is small enough to be picked up. The calculation now uses the cubic root of the pickup's volume instead of the average of its XYZ dimension magnitudes.